### PR TITLE
Small medical.Item edits for imports/exports

### DIFF
--- a/medical/gql_mutations.py
+++ b/medical/gql_mutations.py
@@ -125,11 +125,11 @@ def update_or_create_item_or_service(data, user, item_service_model):
         item_service = item_service_model.objects.get(uuid=item_service_uuid)
         reset_item_or_service_before_update(item_service)
         [setattr(item_service, key, data[key]) for key in data]
+        item_service.save()
     else:
         if item_service_model.objects.all().filter(code=data['code'], validity_to__isnull=True).exists():
             raise CodeAlreadyExistsError(_("Code already exists."))
         item_service = item_service_model.objects.create(**data)
-    item_service.save()
     if client_mutation_id:
         if isinstance(item_service, Service):
             ServiceMutation.object_mutated(user, client_mutation_id=client_mutation_id, service=item_service)

--- a/medical/services.py
+++ b/medical/services.py
@@ -20,3 +20,18 @@ def set_item_or_service_deleted(item_service, item_or_service_element):
                            % {'uuid': item_service.uuid},
                 'detail': item_service.uuid}]
         }
+
+
+def clear_item_dict(item):
+    new_dict = {
+        "code": item.code,
+        "name": item.name,
+        "type": item.type,
+        "price": item.price,
+        "care_type": item.care_type,
+        "patient_category": item.patient_category,
+        "package": item.package,
+        "quantity": item.quantity,
+        "frequency": item.frequency,
+    }
+    return new_dict


### PR DESCRIPTION
Added a `Item.__bool__` that was necessary for the export plugin.
Fixed a bug related to items history being improperly saved through mutations.
Added a service function used for saving history during imports.  